### PR TITLE
Zirkulation korrigiert

### DIFF
--- a/custom_components/kwb_heating/async_modular_register_manager.py
+++ b/custom_components/kwb_heating/async_modular_register_manager.py
@@ -53,8 +53,8 @@ class AsyncModularRegisterManager:
             "is_zero_indexed": True,
             "filename": "circulation.json",
             "lang": {
-                "de": {"name": "Zirkulation", "prefix": "ZIR"},
-                "en": {"name": "Circulation", "prefix": "CIRC"}
+                "de": {"name": "Zirkulation", "prefix": "Zirk"},
+                "en": {"name": "Circulation", "prefix": "Circ"}
             }
         },
         "solar": {


### PR DESCRIPTION
Die Index-Benennung für die Zirkulation war nicht korrekt. Ich habe sie korrigiert auf "Circ" (en) und "Zirk" (de). In meiner Anwendung von home-assistant funktioniert nun auch die Zirkulation.